### PR TITLE
fix: return tuple including multiple empty lists

### DIFF
--- a/cookit_frontend/communcation.py
+++ b/cookit_frontend/communcation.py
@@ -12,5 +12,6 @@ def get_predictions(image):
         res = response.json()
         print('Received predictions: ', res)
         return (res['prediction'], res['scores'], res['bboxes'])
+
     print(f'Something went wong. Received code {response.status_code}')
-    return []
+    return ([], [], [])


### PR DESCRIPTION
in case we receive other status_code than 200 to avoid error in api.py which expects now multiple objects to be returned